### PR TITLE
Fix progressDialog setValue type error by converting float to int

### DIFF
--- a/player.py
+++ b/player.py
@@ -1195,7 +1195,7 @@ def update_media(browser=False):
         video_filename = os.path.basename(video_path)
         mw.progressDialog.setLabelText(video_filename)
 
-        mw.progressDialog.setValue((idx * 1.0 / len(videos)) * 100)
+        mw.progressDialog.setValue(int((idx * 1.0 / len(videos)) * 100))
 
         audio_id = -1
         with no_bundled_libs():


### PR DESCRIPTION
solved this error:

Traceback (most recent call last):
  File "../addons21/939347702/player.py", line 1198, in update_media
    mw.progressDialog.setValue((idx * 1 / len(videos)) * 100)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: setValue(self, progress: int): argument 1 has unexpected type 'float'